### PR TITLE
filter CRD schema to not break (too) strict kube-openapi model validator

### DIFF
--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/conversion.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/conversion.go
@@ -17,6 +17,8 @@ limitations under the License.
 package openapi
 
 import (
+	"strings"
+
 	"github.com/go-openapi/spec"
 
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
@@ -37,6 +39,63 @@ func ConvertJSONSchemaPropsToOpenAPIv2Schema(in *apiextensions.JSONSchemaProps) 
 		// TODO(roycaihw): preserve cases where we only have one subtree in AnyOf, same for OneOf
 		p.AnyOf = nil
 		p.Not = nil
+
+		// TODO: drop everything below in 1.15 when we have passed one version skew towards kube-openapi in <1.14, which rejects valid openapi schemata
+
+		if p.Ref.String() != "" {
+			// https://github.com/kubernetes/kube-openapi/pull/143/files#diff-62afddb578e9db18fb32ffb6b7802d92R95
+			p.Properties = nil
+
+			// https://github.com/kubernetes/kube-openapi/pull/143/files#diff-62afddb578e9db18fb32ffb6b7802d92R99
+			p.Type = nil
+
+			// https://github.com/kubernetes/kube-openapi/pull/143/files#diff-62afddb578e9db18fb32ffb6b7802d92R104
+			if !strings.HasPrefix(p.Ref.String(), "#/definitions/") {
+				p.Ref = spec.Ref{}
+			}
+		}
+
+		if len(p.Type) > 1 {
+			// https://github.com/kubernetes/kube-openapi/pull/143/files#diff-62afddb578e9db18fb32ffb6b7802d92R272
+			// We also set Properties to null to enforce parseArbitrary at https://github.com/kubernetes/kube-openapi/blob/814a8073653e40e0e324205d093770d4e7bb811f/pkg/util/proto/document.go#L247
+			p.Type = nil
+			p.Properties = nil
+		} else if len(p.Type) == 1 {
+			switch p.Type[0] {
+			case "null":
+				// https://github.com/kubernetes/kube-openapi/pull/143/files#diff-ce77fea74b9dd098045004410023e0c3R219
+				p.Type = nil
+			case "array":
+				// https://github.com/kubernetes/kube-openapi/pull/143/files#diff-62afddb578e9db18fb32ffb6b7802d92R183
+				// https://github.com/kubernetes/kube-openapi/pull/143/files#diff-62afddb578e9db18fb32ffb6b7802d92R184
+				if p.Items == nil || (p.Items.Schema == nil && len(p.Items.Schemas) != 1) {
+					p.Type = nil
+					p.Items = nil
+				}
+			}
+		} else {
+			// https://github.com/kubernetes/kube-openapi/pull/143/files#diff-62afddb578e9db18fb32ffb6b7802d92R248
+			p.Properties = nil
+		}
+
+		// normalize items
+		if p.Items != nil && len(p.Items.Schemas) == 1 {
+			p.Items = &spec.SchemaOrArray{Schema: &p.Items.Schemas[0]}
+		}
+
+		// general fixups not supported by gnostic
+		p.ID = ""
+		p.Schema = ""
+		p.Definitions = nil
+		p.AdditionalItems = nil
+		p.Dependencies = nil
+		p.PatternProperties = nil
+		if p.ExternalDocs != nil && len(p.ExternalDocs.URL) == 0 {
+			p.ExternalDocs = nil
+		}
+		if p.Items != nil && p.Items.Schemas != nil {
+			p.Items = nil
+		}
 
 		return nil
 	})

--- a/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/conversion_test.go
+++ b/staging/src/k8s.io/apiextensions-apiserver/pkg/controller/openapi/conversion_test.go
@@ -17,12 +17,23 @@ limitations under the License.
 package openapi
 
 import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"math/rand"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/go-openapi/spec"
+	"github.com/google/gofuzz"
+	"github.com/googleapis/gnostic/OpenAPIv2"
+	"github.com/googleapis/gnostic/compiler"
+	"gopkg.in/yaml.v2"
 	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/util/diff"
+	"k8s.io/kube-openapi/pkg/util/proto"
 )
 
 func Test_ConvertJSONSchemaPropsToOpenAPIv2Schema(t *testing.T) {
@@ -525,4 +536,215 @@ func Test_ConvertJSONSchemaPropsToOpenAPIv2Schema(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestKubeOpenapiRejectionFiltering tests that the CRD openapi schema filtering leads to a spec that the
+// kube-openapi/pkg/util/proto model code support in version used in Kubernetes 1.13.
+func TestKubeOpenapiRejectionFiltering(t *testing.T) {
+	for i := 0; i < 10000; i++ {
+		t.Run(fmt.Sprintf("iteration %d", i), func(t *testing.T) {
+			f := fuzz.New()
+			seed := time.Now().UnixNano()
+			//seed = int64(1550678935445547778)
+			randSource := rand.New(rand.NewSource(seed))
+			f.RandSource(randSource)
+			t.Logf("seed = %d", seed)
+
+			fuzzFuncs(f, func(ref *spec.Ref, c fuzz.Continue, visible bool) {
+				var url string
+				if c.RandBool() {
+					url = fmt.Sprintf("http://%d", c.Intn(100000))
+				} else {
+					url = "#/definitions/test"
+				}
+				r, err := spec.NewRef(url)
+				if err != nil {
+					t.Fatalf("failed to fuzz ref: %v", err)
+				}
+				*ref = r
+			})
+
+			// create go-openapi object and fuzz it (we start here because we have the powerful fuzzer already
+			s := &spec.Schema{}
+			f.Fuzz(s)
+
+			// convert to apiextensions v1beta1
+			bs, err := json.Marshal(s)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Log(string(bs))
+
+			var schema *apiextensionsv1beta1.JSONSchemaProps
+			if err := json.Unmarshal(bs, &schema); err != nil {
+				t.Fatalf("failed to unmarshal JSON into apiextensions/v1beta1: %v", err)
+			}
+
+			// convert to internal
+			internalSchema := &apiextensions.JSONSchemaProps{}
+			if err := apiextensionsv1beta1.Convert_v1beta1_JSONSchemaProps_To_apiextensions_JSONSchemaProps(schema, internalSchema, nil); err != nil {
+				t.Fatalf("failed to convert from apiextensions/v1beta1 to internal: %v", err)
+			}
+
+			// apply the filter
+			filtered, err := ConvertJSONSchemaPropsToOpenAPIv2Schema(internalSchema)
+			if err != nil {
+				t.Fatalf("failed to filter: %v", err)
+			}
+
+			// create a doc out of it
+			filteredSwagger := &spec.Swagger{
+				SwaggerProps: spec.SwaggerProps{
+					Definitions: spec.Definitions{
+						"test": *filtered,
+					},
+					Info: &spec.Info{
+						InfoProps: spec.InfoProps{
+							Description: "test",
+							Version:     "test",
+							Title:       "test",
+						},
+					},
+					Swagger: "2.0",
+				},
+			}
+
+			// convert to JSON
+			bs, err = json.Marshal(filteredSwagger)
+			if err != nil {
+				t.Fatalf("failed to encode filtered to JSON: %v", err)
+			}
+
+			// unmarshal as yaml
+			var yml yaml.MapSlice
+			if err := yaml.Unmarshal(bs, &yml); err != nil {
+				t.Fatalf("failed to decode filtered JSON by into memory: %v", err)
+			}
+
+			// create gnostic doc
+			doc, err := openapi_v2.NewDocument(yml, compiler.NewContext("$root", nil))
+			if err != nil {
+				t.Fatalf("failed to create gnostic doc: %v", err)
+			}
+
+			// load with kube-openapi/pkg/util/proto
+			if _, err := proto.NewOpenAPIData(doc); err != nil {
+				t.Fatalf("failed to convert to kube-openapi/pkg/util/proto model: %V", err)
+			}
+		})
+	}
+}
+
+// fuzzFuncs is copied from kube-openapi/pkg/aggregator. It fuzzes go-openapi/spec schemata.
+func fuzzFuncs(f *fuzz.Fuzzer, refFunc func(ref *spec.Ref, c fuzz.Continue, visible bool)) {
+	invisible := 0 // == 0 means visible, > 0 means invisible
+	depth := 0
+	maxDepth := 3
+	nilChance := func(depth int) float64 {
+		return math.Pow(0.9, math.Max(0.0, float64(maxDepth-depth)))
+	}
+	updateFuzzer := func(depth int) {
+		f.NilChance(nilChance(depth))
+		f.NumElements(0, max(0, maxDepth-depth))
+	}
+	updateFuzzer(depth)
+	enter := func(o interface{}, recursive bool, c fuzz.Continue) {
+		if recursive {
+			depth++
+			updateFuzzer(depth)
+		}
+
+		invisible++
+		c.FuzzNoCustom(o)
+		invisible--
+	}
+	leave := func(recursive bool) {
+		if recursive {
+			depth--
+			updateFuzzer(depth)
+		}
+	}
+	f.Funcs(
+		func(ref *spec.Ref, c fuzz.Continue) {
+			refFunc(ref, c, invisible == 0)
+		},
+		func(sa *spec.SchemaOrStringArray, c fuzz.Continue) {
+			*sa = spec.SchemaOrStringArray{}
+			if c.RandBool() {
+				c.Fuzz(&sa.Schema)
+			} else {
+				c.Fuzz(&sa.Property)
+			}
+			if sa.Schema == nil && len(sa.Property) == 0 {
+				*sa = spec.SchemaOrStringArray{Schema: &spec.Schema{}}
+			}
+		},
+		func(url *spec.SchemaURL, c fuzz.Continue) {
+			*url = spec.SchemaURL("http://url")
+		},
+		func(s *spec.Dependencies, c fuzz.Continue) {
+			enter(s, false, c)
+			defer leave(false)
+
+			// and nothing with invisible==false
+		},
+		func(p *spec.SimpleSchema, c fuzz.Continue) {
+			// gofuzz is broken and calls this even for *SimpleSchema fields, ignoring NilChance, leading to infinite recursion
+			if c.Float64() > nilChance(depth) {
+				return
+			}
+
+			enter(p, true, c)
+			defer leave(true)
+
+			c.FuzzNoCustom(p)
+
+			// reset JSON fields to some correct JSON
+			if p.Default != nil {
+				p.Default = "42"
+			}
+			if p.Example != nil {
+				p.Example = "42"
+			}
+		},
+		func(s *spec.SchemaProps, c fuzz.Continue) {
+			// gofuzz is broken and calls this even for *SchemaProps fields, ignoring NilChance, leading to infinite recursion
+			if c.Float64() > nilChance(depth) {
+				return
+			}
+
+			enter(s, true, c)
+			defer leave(true)
+
+			c.FuzzNoCustom(s)
+
+			// we don't support multi-type schema props yet in apiextensions/v1beta1
+			if len(s.Type) > 1 {
+				s.Type = s.Type[:1]
+
+				s := apiextensionsv1beta1.JSONSchemaProps{}
+				if reflect.TypeOf(s.Type).String() != "string" {
+					panic(fmt.Errorf("this simplifaction is outdated: apiextensions/v1beta1 types not a single string anymore, but %T", s.Type))
+				}
+			}
+
+			// reset JSON fields to some correct JSON
+			if s.Default != nil {
+				s.Default = "42"
+			}
+			for i := range s.Enum {
+				s.Enum[i] = "42"
+			}
+		},
+		func(i *interface{}, c fuzz.Continue) {
+			// do nothing for examples and defaults. These are free form JSON fields.
+		},
+	)
+}
+
+func max(i, j int) int {
+	if i > j {
+		return i
+	}
+	return j
 }

--- a/test/e2e/apimachinery/crd_publish_openapi.go
+++ b/test/e2e/apimachinery/crd_publish_openapi.go
@@ -411,14 +411,17 @@ func definitionName(crd *framework.TestCrd, version string) string {
 }
 
 var schemaFoo = []byte(`description: Foo CRD for Testing
+type: object
 properties:
   spec:
+    type: object
     description: Specification of Foo
     properties:
       bars:
         description: List of Bars and their specs.
         type: array
         items:
+          type: object
           required:
           - name
           properties:
@@ -435,11 +438,13 @@ properties:
               type: array
   status:
     description: Status of Foo
+    type: object
     properties:
       bars:
         description: List of Bars and their statuses.
         type: array
         items:
+          type: object
           properties:
             name:
               description: Name of Bar.
@@ -453,6 +458,7 @@ properties:
               type: string`)
 
 var schemaWaldo = []byte(`description: Waldo CRD for Testing
+type: object
 properties:
   spec:
     description: Specification of Waldo


### PR DESCRIPTION
* First commit add filtering of the spec to be compatible with kube <= 1.13 kube-openapi, i.e. to work despite https://github.com/kubernetes/kube-openapi/pull/143.
* Second commit fixes test specs. 
* Third commit fixes filtering to not drop properties if type is empty. This is related to [kubernetes/kube-openapi@f4cb700](https://github.com/kubernetes/kube-openapi/commit/f4cb700db16793e5065e76fa9c064c022ce59673). In kube-openapi this hack assumes to always see an object at the root.